### PR TITLE
1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.2.1 / 2015-03-01
+------------------
+- now using standard for code formatting
+- now using `pbkdf2` module over `pbkdf2-sha256`, huge performance increase in Node
+
 1.2.0 / 2014-12-11
 ------------------
 - upgraded `pbkdf2-sha256` from `1.0.1` to `1.1.0`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scryptsy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pure JavaScript implementation of the scrypt key deriviation function that is fully compatible with Node.js and the browser.",
   "main": "lib/scrypt.js",
   "author": "",


### PR DESCRIPTION
Changes:

- Now using [standard](https://github.com/feross/standard)
- Now using [pbkdf2](https://github.com/crypto-browserify/pbkdf2), huge performance increase in Node
