### PR TITLE
2.1.0: add optional async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+coverage/
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
-  - "5"
-  - "6"
+  - "8"
+  - "lts/*"
 matrix:
   include:
-    - node_js: "6"
+    - node_js: "8"
       env: TEST_SUITE=lint
 env:
   - TEST_SUITE=unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.0.0 / 2019-03-12
+------------------
+- **breaking** Import gives an object with two functions `scrypt` and `scryptSync`
+- `scryptSync` is the old synchronus function.
+- `scrypt` will return a promise with the buffer.
+
 2.0.0 / 2016-05-26
 ------------------
 - **breaking** Node v0.10 not supported anymore.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ async function main () {
   console.log(data1.toString('hex'))
   // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
+  // async is actually slower, but it will free up the event loop occasionally
+  // which will allow for front end GUI elements to update and cause it to not
+  // freeze up.
   var data2 = await scrypt(key, salt, 16384, 8, 1, 64)
   console.log(data2.toString('hex'))
   // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887

--- a/README.md
+++ b/README.md
@@ -45,13 +45,70 @@ async function main () {
   // async is actually slower, but it will free up the event loop occasionally
   // which will allow for front end GUI elements to update and cause it to not
   // freeze up.
-  var data2 = await scrypt(key, salt, 16384, 8, 1, 64)
+  // See benchmarks below
+  // Passing 300 below means every 300 iterations internally will call setImmediate once
+  var data2 = await scrypt(key, salt, 16384, 8, 1, 64, undefined, 300)
   console.log(data2.toString('hex'))
   // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 }
 main().catch(console.error)
 ```
 
+
+Benchmarks
+-------
+
+Internal iterations are N * p, so changing r doesn't affect the number of calls to setImmediate.
+Decreasing pI decreases performance in exchange for more frequently freeing the event loop.
+(pI Default is 5000 loops per setImmediate call)
+
+Note: these benchmarks were done on node v10 on a CPU with good single thread performance.
+browsers show a much larger difference. Please tinker with the pI setting to balance between
+performance and GUI responsiveness.
+
+If `pI >= N`, setImmediate will only be called `p * 2` times total (on the i = 0 of each for loop).
+
+```
+---------------------------
+time    : type : (N,r,p,pI) (pI = promiseInterval)
+---------------------------
+2266 ms :  sync (2^16,16,1)
+2548 ms : async (2^16,16,1,5000)
+12.44% increase
+---------------------------
+2616 ms :  sync (2^16,1,16)
+2995 ms : async (2^16,1,16,5000)
+14.49% increase
+---------------------------
+2685 ms :  sync (2^20,1,1)
+3090 ms : async (2^20,1,1,5000)
+15.08% increase
+---------------------------
+2235 ms :  sync (2^16,16,1)
+2627 ms : async (2^16,16,1,10)
+17.54% increase
+---------------------------
+2592 ms :  sync (2^16,1,16)
+3305 ms : async (2^16,1,16,10)
+27.51% increase
+---------------------------
+2705 ms :  sync (2^20,1,1)
+3363 ms : async (2^20,1,1,10)
+24.33% increase
+---------------------------
+2278 ms :  sync (2^16,16,1)
+2773 ms : async (2^16,16,1,1)
+21.73% increase
+---------------------------
+2617 ms :  sync (2^16,1,16)
+5632 ms : async (2^16,1,16,1)
+115.21% increase
+---------------------------
+2727 ms :  sync (2^20,1,1)
+5723 ms : async (2^20,1,1,1)
+109.86% increase
+---------------------------
+```
 
 API
 ---
@@ -66,9 +123,9 @@ API
 - **keyLenBytes**: The number of bytes to return. `number` (integer)
 - **progressCallback**: Call callback on every `1000` ops. Passes in `{current, total, percent}` as first parameter to `progressCallback()`.
 
-Returns `Promise<Buffer>`.
+Returns `Buffer`.
 
-### scryptSync(key, salt, N, r, p, keyLenBytes, [progressCallback])
+### scrypt.async(key, salt, N, r, p, keyLenBytes, [progressCallback, promiseInterval])
 
 - **key**: The key. Either `Buffer` or `string`.
 - **salt**: The salt. Either `Buffer` or `string`.
@@ -77,8 +134,9 @@ Returns `Promise<Buffer>`.
 - **p**: Parallelization factor. `number` (integer)
 - **keyLenBytes**: The number of bytes to return. `number` (integer)
 - **progressCallback**: Call callback on every `1000` ops. Passes in `{current, total, percent}` as first parameter to `progressCallback()`.
+- **promiseInterval**: The number of internal iterations before calling setImmediate once to free the event loop.
 
-Returns `Buffer`.
+Returns `Promise<Buffer>`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const scrypt = require('scryptsy')
 async function main () {
   var key = "pleaseletmein"
   var salt = "SodiumChloride"
-  var data1 = scryptSync(key, salt, 16384, 8, 1, 64)
+  var data1 = scrypt(key, salt, 16384, 8, 1, 64)
   console.log(data1.toString('hex'))
   // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function main () {
   // freeze up.
   // See benchmarks below
   // Passing 300 below means every 300 iterations internally will call setImmediate once
-  var data2 = await scrypt(key, salt, 16384, 8, 1, 64, undefined, 300)
+  var data2 = await scrypt.async(key, salt, 16384, 8, 1, 64, undefined, 300)
   console.log(data2.toString('hex'))
   // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 }

--- a/README.md
+++ b/README.md
@@ -26,13 +26,20 @@ Example
 -------
 
 ```js
-var scrypt = require('scryptsy')
+const { scrypt, scryptSync } = require('scryptsy')
 
-var key = "pleaseletmein"
-var salt = "SodiumChloride"
-var data = scrypt(key, salt, 16384, 8, 1, 64)
-console.log(data.toString('hex'))
-// => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
+async function main () {
+  var key = "pleaseletmein"
+  var salt = "SodiumChloride"
+  var data1 = scryptSync(key, salt, 16384, 8, 1, 64)
+  console.log(data1.toString('hex'))
+  // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
+
+  var data2 = await scrypt(key, salt, 16384, 8, 1, 64)
+  console.log(data2.toString('hex'))
+  // => 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
+}
+main().catch(console.error)
 ```
 
 
@@ -40,6 +47,18 @@ API
 ---
 
 ### scrypt(key, salt, N, r, p, keyLenBytes, [progressCallback])
+
+- **key**: The key. Either `Buffer` or `string`.
+- **salt**: The salt. Either `Buffer` or `string`.
+- **N**: The number of iterations. `number` (integer)
+- **r**: Memory factor. `number` (integer)
+- **p**: Parallelization factor. `number` (integer)
+- **keyLenBytes**: The number of bytes to return. `number` (integer)
+- **progressCallback**: Call callback on every `1000` ops. Passes in `{current, total, percent}` as first parameter to `progressCallback()`.
+
+Returns `Promise<Buffer>`.
+
+### scryptSync(key, salt, N, r, p, keyLenBytes, [progressCallback])
 
 - **key**: The key. Either `Buffer` or `string`.
 - **salt**: The salt. Either `Buffer` or `string`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Installation
 
 
 
+Browserify Note
+------------
+
+When using a browserified bundle, be sure to add `setImmediate` as a shim.
+
+
+
 Example
 -------
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Example
 -------
 
 ```js
-const { scrypt, scryptSync } = require('scryptsy')
+const scrypt = require('scryptsy')
 
 async function main () {
   var key = "pleaseletmein"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  scrypt: require('./scrypt'),
+  scryptSync: require('./scryptSync')
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-module.exports = {
-  scrypt: require('./scrypt'),
-  scryptSync: require('./scryptSync')
-}
+const scrypt = require('./scryptSync')
+scrypt.async = require('./scrypt')
+module.exports = scrypt

--- a/lib/scrypt.js
+++ b/lib/scrypt.js
@@ -1,180 +1,43 @@
-var crypto = require('crypto')
-/* eslint-disable camelcase */
-
-var MAX_VALUE = 0x7fffffff
+const crypto = require('crypto')
+const {
+  checkAndInit,
+  smix
+} = require('./utils')
 
 // N = Cpu cost, r = Memory cost, p = parallelization cost
 function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
-  if (N === 0 || (N & (N - 1)) !== 0) throw Error('N must be > 0 and a power of 2')
+  const {
+    XY,
+    V,
+    B32,
+    x,
+    _X,
+    B,
+    tickCallback
+  } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
 
-  if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large')
-  if (r > MAX_VALUE / 128 / p) throw Error('Parameter r is too large')
-
-  var XY = new Buffer(256 * r)
-  var V = new Buffer(128 * r * N)
-
-  // pseudo global
-  var B32 = new Int32Array(16) // salsa20_8
-  var x = new Int32Array(16) // salsa20_8
-  var _X = new Buffer(64) // blockmix_salsa8
-
-  // pseudo global
-  var B = crypto.pbkdf2Sync(key, salt, 1, p * 128 * r, 'sha256')
-
-  var tickCallback
-  if (progressCallback) {
-    var totalOps = p * N * 2
-    var currentOp = 0
-
-    tickCallback = function () {
-      ++currentOp
-
-      // send progress notifications once every 1,000 ops
-      if (currentOp % 1000 === 0) {
-        progressCallback({
-          current: currentOp,
-          total: totalOps,
-          percent: (currentOp / totalOps) * 100.0
+  function smixFunc (i, p, doneCallback) {
+    try {
+      if (i === p) {
+        doneCallback(null, crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256'))
+      } else {
+        smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+        setImmediate(function () {
+          smixFunc(i + 1, p, doneCallback)
         })
       }
+    } catch (error) {
+      doneCallback(error)
     }
   }
 
-  for (var i = 0; i < p; i++) {
-    smix(B, i * 128 * r, r, N, V, XY)
-  }
-
-  return crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256')
-
-  // all of these functions are actually moved to the top
-  // due to function hoisting
-
-  function smix (B, Bi, r, N, V, XY) {
-    var Xi = 0
-    var Yi = 128 * r
-    var i
-
-    B.copy(XY, Xi, Bi, Bi + Yi)
-
-    for (i = 0; i < N; i++) {
-      XY.copy(V, i * Yi, Xi, Xi + Yi)
-      blockmix_salsa8(XY, Xi, Yi, r)
-
-      if (tickCallback) tickCallback()
+  return new Promise(function (resolve, reject) {
+    let doneCallback = function (error, buffer) {
+      if (error) return reject(error)
+      else return resolve(buffer)
     }
-
-    for (i = 0; i < N; i++) {
-      var offset = Xi + (2 * r - 1) * 64
-      var j = XY.readUInt32LE(offset) & (N - 1)
-      blockxor(V, j * Yi, XY, Xi, Yi)
-      blockmix_salsa8(XY, Xi, Yi, r)
-
-      if (tickCallback) tickCallback()
-    }
-
-    XY.copy(B, Bi, Xi, Xi + Yi)
-  }
-
-  function blockmix_salsa8 (BY, Bi, Yi, r) {
-    var i
-
-    arraycopy(BY, Bi + (2 * r - 1) * 64, _X, 0, 64)
-
-    for (i = 0; i < 2 * r; i++) {
-      blockxor(BY, i * 64, _X, 0, 64)
-      salsa20_8(_X)
-      arraycopy(_X, 0, BY, Yi + (i * 64), 64)
-    }
-
-    for (i = 0; i < r; i++) {
-      arraycopy(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64)
-    }
-
-    for (i = 0; i < r; i++) {
-      arraycopy(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64)
-    }
-  }
-
-  function R (a, b) {
-    return (a << b) | (a >>> (32 - b))
-  }
-
-  function salsa20_8 (B) {
-    var i
-
-    for (i = 0; i < 16; i++) {
-      B32[i] = (B[i * 4 + 0] & 0xff) << 0
-      B32[i] |= (B[i * 4 + 1] & 0xff) << 8
-      B32[i] |= (B[i * 4 + 2] & 0xff) << 16
-      B32[i] |= (B[i * 4 + 3] & 0xff) << 24
-      // B32[i] = B.readUInt32LE(i*4)   <--- this is signficantly slower even in Node.js
-    }
-
-    arraycopy(B32, 0, x, 0, 16)
-
-    for (i = 8; i > 0; i -= 2) {
-      x[4] ^= R(x[0] + x[12], 7)
-      x[8] ^= R(x[4] + x[0], 9)
-      x[12] ^= R(x[8] + x[4], 13)
-      x[0] ^= R(x[12] + x[8], 18)
-      x[9] ^= R(x[5] + x[1], 7)
-      x[13] ^= R(x[9] + x[5], 9)
-      x[1] ^= R(x[13] + x[9], 13)
-      x[5] ^= R(x[1] + x[13], 18)
-      x[14] ^= R(x[10] + x[6], 7)
-      x[2] ^= R(x[14] + x[10], 9)
-      x[6] ^= R(x[2] + x[14], 13)
-      x[10] ^= R(x[6] + x[2], 18)
-      x[3] ^= R(x[15] + x[11], 7)
-      x[7] ^= R(x[3] + x[15], 9)
-      x[11] ^= R(x[7] + x[3], 13)
-      x[15] ^= R(x[11] + x[7], 18)
-      x[1] ^= R(x[0] + x[3], 7)
-      x[2] ^= R(x[1] + x[0], 9)
-      x[3] ^= R(x[2] + x[1], 13)
-      x[0] ^= R(x[3] + x[2], 18)
-      x[6] ^= R(x[5] + x[4], 7)
-      x[7] ^= R(x[6] + x[5], 9)
-      x[4] ^= R(x[7] + x[6], 13)
-      x[5] ^= R(x[4] + x[7], 18)
-      x[11] ^= R(x[10] + x[9], 7)
-      x[8] ^= R(x[11] + x[10], 9)
-      x[9] ^= R(x[8] + x[11], 13)
-      x[10] ^= R(x[9] + x[8], 18)
-      x[12] ^= R(x[15] + x[14], 7)
-      x[13] ^= R(x[12] + x[15], 9)
-      x[14] ^= R(x[13] + x[12], 13)
-      x[15] ^= R(x[14] + x[13], 18)
-    }
-
-    for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i]
-
-    for (i = 0; i < 16; i++) {
-      var bi = i * 4
-      B[bi + 0] = (B32[i] >> 0 & 0xff)
-      B[bi + 1] = (B32[i] >> 8 & 0xff)
-      B[bi + 2] = (B32[i] >> 16 & 0xff)
-      B[bi + 3] = (B32[i] >> 24 & 0xff)
-      // B.writeInt32LE(B32[i], i*4)  //<--- this is signficantly slower even in Node.js
-    }
-  }
-
-  // naive approach... going back to loop unrolling may yield additional performance
-  function blockxor (S, Si, D, Di, len) {
-    for (var i = 0; i < len; i++) {
-      D[Di + i] ^= S[Si + i]
-    }
-  }
-}
-
-function arraycopy (src, srcPos, dest, destPos, length) {
-  if (Buffer.isBuffer(src) && Buffer.isBuffer(dest)) {
-    src.copy(dest, destPos, srcPos, srcPos + length)
-  } else {
-    while (length--) {
-      dest[destPos++] = src[srcPos++]
-    }
-  }
+    smixFunc(0, p, doneCallback)
+  })
 }
 
 module.exports = scrypt

--- a/lib/scrypt.js
+++ b/lib/scrypt.js
@@ -6,37 +6,38 @@ const {
 
 // N = Cpu cost, r = Memory cost, p = parallelization cost
 function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
-  const {
-    XY,
-    V,
-    B32,
-    x,
-    _X,
-    B,
-    tickCallback
-  } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
-
-  function smixFunc (i, p, doneCallback) {
-    try {
-      if (i === p) {
-        doneCallback(null, crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256'))
-      } else {
-        smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
-        setImmediate(function () {
-          smixFunc(i + 1, p, doneCallback)
-        })
-      }
-    } catch (error) {
-      doneCallback(error)
-    }
-  }
-
   return new Promise(function (resolve, reject) {
-    let doneCallback = function (error, buffer) {
-      if (error) return reject(error)
-      else return resolve(buffer)
+    try {
+      const {
+        XY,
+        V,
+        B32,
+        x,
+        _X,
+        B,
+        tickCallback
+      } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
+
+      const smixFunc = function (i, p, doneCallback) {
+        if (i === p) {
+          doneCallback(null, crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256'))
+        } else {
+          smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+          setImmediate(function () {
+            smixFunc(i + 1, p, doneCallback)
+          })
+        }
+      }
+
+      const doneCallback = function (error, buffer) {
+        if (error) return reject(error)
+        else return resolve(buffer)
+      }
+
+      smixFunc(0, p, doneCallback)
+    } catch (error) {
+      return reject(error)
     }
-    smixFunc(0, p, doneCallback)
   })
 }
 

--- a/lib/scrypt.js
+++ b/lib/scrypt.js
@@ -5,40 +5,22 @@ const {
 } = require('./utils')
 
 // N = Cpu cost, r = Memory cost, p = parallelization cost
-function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
-  return new Promise(function (resolve, reject) {
-    try {
-      const {
-        XY,
-        V,
-        B32,
-        x,
-        _X,
-        B,
-        tickCallback
-      } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
+async function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
+  const {
+    XY,
+    V,
+    B32,
+    x,
+    _X,
+    B,
+    tickCallback
+  } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
 
-      const smixFunc = function (i, p, doneCallback) {
-        if (i === p) {
-          doneCallback(null, crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256'))
-        } else {
-          smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
-          setImmediate(function () {
-            smixFunc(i + 1, p, doneCallback)
-          })
-        }
-      }
+  for (var i = 0; i < p; i++) {
+    await smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+  }
 
-      const doneCallback = function (error, buffer) {
-        if (error) return reject(error)
-        else return resolve(buffer)
-      }
-
-      smixFunc(0, p, doneCallback)
-    } catch (error) {
-      return reject(error)
-    }
-  })
+  return crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256')
 }
 
 module.exports = scrypt

--- a/lib/scrypt.js
+++ b/lib/scrypt.js
@@ -5,7 +5,7 @@ const {
 } = require('./utils')
 
 // N = Cpu cost, r = Memory cost, p = parallelization cost
-async function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
+async function scrypt (key, salt, N, r, p, dkLen, progressCallback, promiseInterval) {
   const {
     XY,
     V,
@@ -17,7 +17,7 @@ async function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
   } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
 
   for (var i = 0; i < p; i++) {
-    await smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+    await smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback, promiseInterval)
   }
 
   return crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256')

--- a/lib/scryptSync.js
+++ b/lib/scryptSync.js
@@ -1,0 +1,26 @@
+const crypto = require('crypto')
+const {
+  checkAndInit,
+  smix
+} = require('./utils')
+
+// N = Cpu cost, r = Memory cost, p = parallelization cost
+function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
+  const {
+    XY,
+    V,
+    B32,
+    x,
+    _X,
+    B,
+    tickCallback
+  } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
+
+  for (var i = 0; i < p; i++) {
+    smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+  }
+
+  return crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256')
+}
+
+module.exports = scrypt

--- a/lib/scryptSync.js
+++ b/lib/scryptSync.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 const {
   checkAndInit,
-  smix
+  smixSync
 } = require('./utils')
 
 // N = Cpu cost, r = Memory cost, p = parallelization cost
@@ -17,7 +17,7 @@ function scrypt (key, salt, N, r, p, dkLen, progressCallback) {
   } = checkAndInit(key, salt, N, r, p, dkLen, progressCallback)
 
   for (var i = 0; i < p; i++) {
-    smix(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
+    smixSync(B, i * 128 * r, r, N, V, XY, _X, B32, x, tickCallback)
   }
 
   return crypto.pbkdf2Sync(key, B, 1, dkLen, 'sha256')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,181 @@
+const crypto = require('crypto')
+const MAX_VALUE = 0x7fffffff
+/* eslint-disable camelcase */
+
+function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {
+  if (N === 0 || (N & (N - 1)) !== 0) throw Error('N must be > 0 and a power of 2')
+
+  if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large')
+  if (r > MAX_VALUE / 128 / p) throw Error('Parameter r is too large')
+
+  let XY = Buffer.alloc(256 * r)
+  let V = Buffer.alloc(128 * r * N)
+
+  // pseudo global
+  let B32 = new Int32Array(16) // salsa20_8
+  let x = new Int32Array(16) // salsa20_8
+  let _X = Buffer.alloc(64) // blockmix_salsa8
+
+  // pseudo global
+  let B = crypto.pbkdf2Sync(key, salt, 1, p * 128 * r, 'sha256')
+
+  let tickCallback
+  if (progressCallback) {
+    let totalOps = p * N * 2
+    let currentOp = 0
+
+    tickCallback = function () {
+      ++currentOp
+
+      // send progress notifications once every 1,000 ops
+      if (currentOp % 1000 === 0) {
+        progressCallback({
+          current: currentOp,
+          total: totalOps,
+          percent: (currentOp / totalOps) * 100.0
+        })
+      }
+    }
+  }
+  return {
+    XY,
+    V,
+    B32,
+    x,
+    _X,
+    B,
+    tickCallback
+  }
+}
+
+function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
+  let Xi = 0
+  let Yi = 128 * r
+  let i
+
+  B.copy(XY, Xi, Bi, Bi + Yi)
+
+  for (i = 0; i < N; i++) {
+    XY.copy(V, i * Yi, Xi, Xi + Yi)
+    blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+
+    if (tickCallback) tickCallback()
+  }
+
+  for (i = 0; i < N; i++) {
+    let offset = Xi + (2 * r - 1) * 64
+    let j = XY.readUInt32LE(offset) & (N - 1)
+    blockxor(V, j * Yi, XY, Xi, Yi)
+    blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+
+    if (tickCallback) tickCallback()
+  }
+
+  XY.copy(B, Bi, Xi, Xi + Yi)
+}
+
+function blockmix_salsa8 (BY, Bi, Yi, r, _X, B32, x) {
+  let i
+
+  arraycopy(BY, Bi + (2 * r - 1) * 64, _X, 0, 64)
+
+  for (i = 0; i < 2 * r; i++) {
+    blockxor(BY, i * 64, _X, 0, 64)
+    salsa20_8(_X, B32, x)
+    arraycopy(_X, 0, BY, Yi + (i * 64), 64)
+  }
+
+  for (i = 0; i < r; i++) {
+    arraycopy(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64)
+  }
+
+  for (i = 0; i < r; i++) {
+    arraycopy(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64)
+  }
+}
+
+function R (a, b) {
+  return (a << b) | (a >>> (32 - b))
+}
+
+function salsa20_8 (B, B32, x) {
+  let i
+
+  for (i = 0; i < 16; i++) {
+    B32[i] = (B[i * 4 + 0] & 0xff) << 0
+    B32[i] |= (B[i * 4 + 1] & 0xff) << 8
+    B32[i] |= (B[i * 4 + 2] & 0xff) << 16
+    B32[i] |= (B[i * 4 + 3] & 0xff) << 24
+    // B32[i] = B.readUInt32LE(i*4)   <--- this is signficantly slower even in Node.js
+  }
+
+  arraycopy(B32, 0, x, 0, 16)
+
+  for (i = 8; i > 0; i -= 2) {
+    x[4] ^= R(x[0] + x[12], 7)
+    x[8] ^= R(x[4] + x[0], 9)
+    x[12] ^= R(x[8] + x[4], 13)
+    x[0] ^= R(x[12] + x[8], 18)
+    x[9] ^= R(x[5] + x[1], 7)
+    x[13] ^= R(x[9] + x[5], 9)
+    x[1] ^= R(x[13] + x[9], 13)
+    x[5] ^= R(x[1] + x[13], 18)
+    x[14] ^= R(x[10] + x[6], 7)
+    x[2] ^= R(x[14] + x[10], 9)
+    x[6] ^= R(x[2] + x[14], 13)
+    x[10] ^= R(x[6] + x[2], 18)
+    x[3] ^= R(x[15] + x[11], 7)
+    x[7] ^= R(x[3] + x[15], 9)
+    x[11] ^= R(x[7] + x[3], 13)
+    x[15] ^= R(x[11] + x[7], 18)
+    x[1] ^= R(x[0] + x[3], 7)
+    x[2] ^= R(x[1] + x[0], 9)
+    x[3] ^= R(x[2] + x[1], 13)
+    x[0] ^= R(x[3] + x[2], 18)
+    x[6] ^= R(x[5] + x[4], 7)
+    x[7] ^= R(x[6] + x[5], 9)
+    x[4] ^= R(x[7] + x[6], 13)
+    x[5] ^= R(x[4] + x[7], 18)
+    x[11] ^= R(x[10] + x[9], 7)
+    x[8] ^= R(x[11] + x[10], 9)
+    x[9] ^= R(x[8] + x[11], 13)
+    x[10] ^= R(x[9] + x[8], 18)
+    x[12] ^= R(x[15] + x[14], 7)
+    x[13] ^= R(x[12] + x[15], 9)
+    x[14] ^= R(x[13] + x[12], 13)
+    x[15] ^= R(x[14] + x[13], 18)
+  }
+
+  for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i]
+
+  for (i = 0; i < 16; i++) {
+    let bi = i * 4
+    B[bi + 0] = (B32[i] >> 0 & 0xff)
+    B[bi + 1] = (B32[i] >> 8 & 0xff)
+    B[bi + 2] = (B32[i] >> 16 & 0xff)
+    B[bi + 3] = (B32[i] >> 24 & 0xff)
+    // B.writeInt32LE(B32[i], i*4)  //<--- this is signficantly slower even in Node.js
+  }
+}
+
+// naive approach... going back to loop unrolling may yield additional performance
+function blockxor (S, Si, D, Di, len) {
+  for (let i = 0; i < len; i++) {
+    D[Di + i] ^= S[Si + i]
+  }
+}
+
+function arraycopy (src, srcPos, dest, destPos, length) {
+  if (Buffer.isBuffer(src) && Buffer.isBuffer(dest)) {
+    src.copy(dest, destPos, srcPos, srcPos + length)
+  } else {
+    while (length--) {
+      dest[destPos++] = src[srcPos++]
+    }
+  }
+}
+
+module.exports = {
+  checkAndInit,
+  smix
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto')
 const MAX_VALUE = 0x7fffffff
-const PROMISE_INTERVAL = 5000
+const DEFAULT_PROMISE_INTERVAL = 5000
 /* eslint-disable camelcase */
 
 function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {
@@ -49,7 +49,8 @@ function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {
   }
 }
 
-async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
+async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback, promiseInterval) {
+  promiseInterval = promiseInterval || DEFAULT_PROMISE_INTERVAL
   let Xi = 0
   let Yi = 128 * r
   let i
@@ -58,7 +59,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
 
   for (i = 0; i < N; i++) {
     XY.copy(V, i * Yi, Xi, Xi + Yi)
-    if (i % PROMISE_INTERVAL === 0) {
+    if (i % promiseInterval === 0) {
       await new Promise(resolve => setImmediate(resolve))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
@@ -70,7 +71,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
     let offset = Xi + (2 * r - 1) * 64
     let j = XY.readUInt32LE(offset) & (N - 1)
     blockxor(V, j * Yi, XY, Xi, Yi)
-    if (i % PROMISE_INTERVAL === 0) {
+    if (i % promiseInterval === 0) {
       await new Promise(resolve => setImmediate(resolve))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,10 +60,8 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
     XY.copy(V, i * Yi, Xi, Xi + Yi)
     if (i % PROMISE_INTERVAL === 0) {
       await Promise.resolve()
-      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
-    } else {
-      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
     }
+    blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 
     if (tickCallback) tickCallback()
   }
@@ -74,10 +72,8 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
     blockxor(V, j * Yi, XY, Xi, Yi)
     if (i % PROMISE_INTERVAL === 0) {
       await Promise.resolve()
-      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
-    } else {
-      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
     }
+    blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 
     if (tickCallback) tickCallback()
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto')
 const MAX_VALUE = 0x7fffffff
-const PROMISE_INTERVAL = 100 // every 100 operations free EventLoop
+const PROMISE_INTERVAL = 5000
 /* eslint-disable camelcase */
 
 function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto')
 const MAX_VALUE = 0x7fffffff
+const PROMISE_INTERVAL = 100 // every 100 operations free EventLoop
 /* eslint-disable camelcase */
 
 function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {
@@ -48,7 +49,43 @@ function checkAndInit (key, salt, N, r, p, dkLen, progressCallback) {
   }
 }
 
-function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
+async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
+  let Xi = 0
+  let Yi = 128 * r
+  let i
+
+  B.copy(XY, Xi, Bi, Bi + Yi)
+
+  for (i = 0; i < N; i++) {
+    XY.copy(V, i * Yi, Xi, Xi + Yi)
+    if (i % PROMISE_INTERVAL === 0) {
+      await Promise.resolve()
+      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+    } else {
+      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+    }
+
+    if (tickCallback) tickCallback()
+  }
+
+  for (i = 0; i < N; i++) {
+    let offset = Xi + (2 * r - 1) * 64
+    let j = XY.readUInt32LE(offset) & (N - 1)
+    blockxor(V, j * Yi, XY, Xi, Yi)
+    if (i % PROMISE_INTERVAL === 0) {
+      await Promise.resolve()
+      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+    } else {
+      blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
+    }
+
+    if (tickCallback) tickCallback()
+  }
+
+  XY.copy(B, Bi, Xi, Xi + Yi)
+}
+
+function smixSync (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
   let Xi = 0
   let Yi = 128 * r
   let i
@@ -177,5 +214,6 @@ function arraycopy (src, srcPos, dest, destPos, length) {
 
 module.exports = {
   checkAndInit,
-  smix
+  smix,
+  smixSync
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
   for (i = 0; i < N; i++) {
     XY.copy(V, i * Yi, Xi, Xi + Yi)
     if (i % PROMISE_INTERVAL === 0) {
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await new Promise(resolve => setImmediate(resolve))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 
@@ -71,7 +71,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
     let j = XY.readUInt32LE(offset) & (N - 1)
     blockxor(V, j * Yi, XY, Xi, Yi)
     if (i % PROMISE_INTERVAL === 0) {
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await new Promise(resolve => setImmediate(resolve))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
   for (i = 0; i < N; i++) {
     XY.copy(V, i * Yi, Xi, Xi + Yi)
     if (i % PROMISE_INTERVAL === 0) {
-      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 
@@ -71,7 +71,7 @@ async function smix (B, Bi, r, N, V, XY, _X, B32, x, tickCallback) {
     let j = XY.readUInt32LE(offset) & (N - 1)
     blockxor(V, j * Yi, XY, Xi, Yi)
     if (i % PROMISE_INTERVAL === 0) {
-      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
     }
     blockmix_salsa8(XY, Xi, Yi, r, _X, B32, x)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scryptsy",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Pure JavaScript implementation of the scrypt key deriviation function that is fully compatible with Node.js and the browser.",
   "main": "lib/index.js",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "scryptsy",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Pure JavaScript implementation of the scrypt key deriviation function that is fully compatible with Node.js and the browser.",
-  "main": "lib/scrypt.js",
+  "main": "lib/index.js",
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "coveralls": "^2.10.0",
-    "istanbul": "^0.3.5",
-    "mocha": "^2.2.0",
-    "mochify": "^2.1.0",
-    "standard": "^7.1.1"
+    "coveralls": "^3.0.3",
+    "mocha": "^6.0.2",
+    "mochify": "^6.1.0",
+    "nyc": "^13.3.0",
+    "standard": "^12.0.1"
   },
   "dependencies": {},
   "repository": {
@@ -29,10 +29,10 @@
   ],
   "scripts": {
     "test": "mocha --ui bdd",
-    "unit": "./node_modules/.bin/mocha",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter list test/*.js",
-    "coveralls": "npm run-script coverage && node ./node_modules/.bin/coveralls < coverage/lcov.info",
-    "browser-test": "./node_modules/.bin/mochify --wd -R spec",
+    "unit": "mocha",
+    "coverage": "nyc --check-coverage --statements 80 --branches 60 --functions 90 --lines 90 mocha",
+    "coveralls": "npm run-script coverage && coveralls < coverage/lcov.info",
+    "browser-test": "mochify --wd -R spec",
     "lint": "standard"
   }
 }

--- a/test/scrypt.js
+++ b/test/scrypt.js
@@ -1,7 +1,7 @@
 /* global describe, it */
 
 const assert = require('assert')
-const { scrypt, scryptSync } = require('../')
+const scrypt = require('../')
 
 const fixtures = require('./fixtures')
 
@@ -16,8 +16,8 @@ describe('scrypt', function () {
       if (f.skip) return // impractical to run most times
 
       it('should compute for ' + f.description, async function () {
-        var data1 = await scrypt(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
-        var data2 = scryptSync(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
+        var data1 = await scrypt.async(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
+        var data2 = scrypt(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
 
         assert.strictEqual(data1.toString('hex'), f.result)
         assert.strictEqual(data2.toString('hex'), f.result)

--- a/test/scrypt.js
+++ b/test/scrypt.js
@@ -1,9 +1,9 @@
 /* global describe, it */
 
-var assert = require('assert')
-var scrypt = require('../')
+const assert = require('assert')
+const { scrypt, scryptSync } = require('../')
 
-var fixtures = require('./fixtures')
+const fixtures = require('./fixtures')
 
 // some tests params from: https://github.com/barrysteyn/node-scrypt/blob/master/tests/scrypt-tests.js
 // also: https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-00
@@ -15,10 +15,12 @@ describe('scrypt', function () {
     fixtures.valid.forEach(function (f) {
       if (f.skip) return // impractical to run most times
 
-      it('should compute for ' + f.description, function () {
-        var data = scrypt(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
+      it('should compute for ' + f.description, async function () {
+        var data1 = await scrypt(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
+        var data2 = scryptSync(f.key, f.salt, f.iterations, f.memory, f.parallel, f.keyLen)
 
-        assert.equal(data.toString('hex'), f.result)
+        assert.strictEqual(data1.toString('hex'), f.result)
+        assert.strictEqual(data2.toString('hex'), f.result)
       })
     })
   })


### PR DESCRIPTION
Using setImmediate to allow for browsers to draw the screen and not freeze up.

This includes breaking changes.

Updated tooling as there were some vulnerabilities and deprecated tools.