### PR TITLE
Clean up package contents

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-test/
-.gitignore
-.min-wd

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "lib/index.js",
   "author": "",
   "license": "MIT",
+  "files": [
+    "lib"
+  ],
   "devDependencies": {
     "coveralls": "^3.0.3",
     "mocha": "^6.0.2",


### PR DESCRIPTION
A bunch of coverage junk was getting in the dry-run of npm publish, so instead of a blacklist let's do a whitelist.